### PR TITLE
# 调整样式

### DIFF
--- a/library/Scss/Base.scss
+++ b/library/Scss/Base.scss
@@ -215,7 +215,7 @@
       &.right .item.active {
         &::after {
           left: unset;
-          right: 0;
+          right: 2px;
         }
       }
     }

--- a/library/SplitLayout/SplitN.vue
+++ b/library/SplitLayout/SplitN.vue
@@ -10,8 +10,8 @@
       v-for="(child, index) in grid.childGrid"
       :key="child.name"
       :style="{
-        width: horizontal ? `calc(${child.visible ? child.size : 0}% - ${draggerSize}px)` : undefined,
-        height: horizontal ? undefined : (`calc(${child.visible ? child.size : 0}% - ${draggerSize}px)`),
+        width: horizontal ? `${child.visible ? child.size : 0}%` : undefined,
+        height: horizontal ? undefined : `${child.visible ? child.size : 0}%`,
       }"
       :data-panel-name="child.name"
       class="split-n-container"


### PR DESCRIPTION
1. 调整 .code-layout-root>.code-layout-activity .code-layout-activity-bar.right .item.active:after 的样式，使右侧指示线完全可见。原先在最右侧使用 :after 向右延伸，若右侧活动栏已处于边缘会导致指示线缺失。修改偏移后能看见完整的指示线。

2. code-layout-split-dragger 位于 split-n-container 内部，split-n-container 的宽度已经包含了 draggerSize 的宽度了，不需要再减去宽度。原来那样减去会导致右侧和下侧边缘增加空白间隙。