### PR TITLE
 [Docs] Update docs ｜ 	 [Fix] Fix https://github.com/imengyu/vue-code-layout/issues/30#issuecomment-3589292319 

### DIFF
--- a/docs/api/CodeLayout.md
+++ b/docs/api/CodeLayout.md
@@ -36,13 +36,19 @@ nav:
 | titleBarCenter | 标题栏中心位置 | - |
 | titleBarRight | 标题栏右侧位置 | - |
 | titleBarBottom | 标题栏下方位置 | - |
-| activityBarTopBar | 主活动栏顶部 | - |
+| activityBarTopMenuBar | 主活动栏顶部菜单 | - |
+| activityBarTop | 主活动栏顶部 | - |
+| activityBarEnd | 主活动栏尾部 | - |
 | activityBarBottom | 主活动栏底部 | - |
-| activityBarSecondaryTopBar | 副活动栏顶部 | - |
+| activityBarSecondaryTopMenuBar | 副活动栏顶部菜单 | - |
+| activityBarSecondaryTop | 副活动栏顶部 | - |
+| activityBarSecondaryEnd | 副活动栏尾部 | - |
 | activityBarSecondarBottom | 副活动栏底部 | - |
 | emptyGroup | 空组渲染插槽 | `{ panel: CodeLayoutGridInternal }` |
 | centerArea | 中心区域，这里可以放置SliptLayout或者其他编辑器核心组件 | - |
 | statusBar | 状态栏位置 | - |
+| statusBarLeft | 状态栏左侧 | - |
+| statusBarRight | 状态栏左侧 | - |
 | emptyGroup | 自定义渲染空组内容 | `{ grid: CodeLayoutGrid }` |
 
 ## CodeLayoutInstance
@@ -215,12 +221,11 @@ const config = reactive<CodeLayoutConfig>({
 | primarySideBarMinWidth | 主侧栏的最小大小（像素） | `number` | `170` |
 | secondarySideBarWidth | 辅助侧边栏的大小（0-100，百分比） | `number` | `20` |
 | secondarySideBarMinWidth | 辅助侧边栏的最小大小（像素） | `number` | `170` |
-| secondarySideBarAsActivityBar | 辅助侧边栏是否像主侧边栏一样显示为活动栏 | `boolean` | `false` |
 | bottomPanelHeight | 面板的大小（0-100，百分比） | `number` | `30` |
 | bottomPanelMinHeight | 面板最小大小（像素） | `number` | `40` |
 | panelAlignment | 面板布局位置<ul><li>left: 底部左对齐</li><li>center：底部居中</li><li>right：底部右对齐</li><li>justify：底部两端对齐</li><li>left-side：左侧</li><li>right-side：右侧</li></ul> | `'left'│'center'│'right'│'justify'│'left-side'│'right-side'` | `'center'` |
 | activityBarPosition | 活动栏的布局位置<ul><li>side: 左侧</li><li>top：顶部</li><li>hidden：隐藏</li></ul> | `'side'│'top'│'hidden'` | `'side'` |
-| secondaryActivityBarPosition | 第二活动栏（当 `secondarySideBarAsActivityBar` 设置为 `true`）的布局位置<ul><li>side: 左侧</li><li>top：顶部</li><li>hidden：隐藏</li></ul> | `'side'│'top'│'hidden'` | `'side'` |
+| secondaryActivityBarPosition | 第二活动栏布局位置<ul><li>side: 左侧</li><li>top：顶部</li><li>hidden：隐藏</li></ul> | `'side'│'top'│'hidden'`| `'side'` |
 | panelHeaderHeight | 面板标题的高度（像素） | `number` | `24` |
 | panelMinHeight | 所有面板缩放最小高度（像素） | `number` | `150` |
 | titleBar | 是否显示标题栏 | `boolean` | `true` |

--- a/docs/en/api/CodeLayout.md
+++ b/docs/en/api/CodeLayout.md
@@ -208,12 +208,11 @@ const config = reactive<CodeLayoutConfig>({
 | primarySideBarMinWidth | The minimum size of the primarySideBar in pixels | `number` | `170` |
 | secondarySideBarWidth | The size of the secondarySideBar (0-100, percentage) | `number` | `20` |
 | secondarySideBarMinWidth | The minimum size of the secondarySideBar in pixels | `number` | `170` |
-| secondarySideBarAsActivityBar | Whether the secondary sidebar appears as an active bar like the primarySidebar | `boolean` | `false` |
 | bottomPanelHeight | The size of the bottomPanel (0-100, percentage) | `number` | `30` |
 | bottomPanelMinHeight | The minimum size of the bottomPanel in pixels | `number` | `40` |
 | panelAlignment | The layout position of the bottomPanel<ul><li>left: At the bottom left</li><li>center: At the bottom center</li><li>right: At the bottom right</li><li>justify: At the bottom center and justify</li><li>left-side: Center left</li><li>right-side: Center right</li></ul> | `'left'│'center'│'right'│'justify'│'left-side'│'right-side'` | `'center'` |
 | activityBarPosition | The position of the activityBar<ul><li>side: Main left</li><li>top: In primarySideBar top</li><li>hidden: No activityBar</li></ul> | `'side'│'top'│'hidden'` | `'side'` |
-| secondaryActivityBarPosition | The position of the secondary activityBar (when `secondarySideBarAsActivityBar` is set to `true`) <ul><li>side: Main left</li><li>top: In primarySideBar top</li><li>hidden: No activityBar</li></ul> | `'side'│'top'│'hidden'` | `'side'` |
+| secondaryActivityBarPosition | The position of the secondary activityBar <ul><li>side: Main left</li><li>top: In primarySideBar top</li><li>hidden: No activityBar</li></ul> | `'side'│'top'│'hidden'` | `'side'` |
 | panelHeaderHeight | The height of the panel title in pixels | `number` | `24` |
 | panelMinHeight | The minimum height (in pixels) for all panels | `number` | `150` |
 | titleBar | Show title bar? | `boolean` | `true` |

--- a/library/CodeLayout.vue
+++ b/library/CodeLayout.vue
@@ -261,40 +261,21 @@ function loadActivityBarPosition() {
       panels.value.primary.tabStyle = layoutConfig.value.activityBar ? 'icon-bottom' : 'hidden';
       break;
   }
-  if (layoutConfig.value.secondarySideBarAsActivityBar)
-  {
-    switch (layoutConfig.value.secondaryActivityBarPosition) {
+   switch (layoutConfig.value.secondaryActivityBarPosition) {
       case 'side':
       case 'hidden':
         panels.value.secondary.tabStyle = 'hidden';
         break;
       case 'top':
-        panels.value.secondary.tabStyle = 'icon';
+        panels.value.secondary.tabStyle = layoutConfig.value.secondarySideBar?'icon':'hidden'
         break;
       case 'bottom':
-        panels.value.secondary.tabStyle = 'icon-bottom';
+        panels.value.secondary.tabStyle = layoutConfig.value.secondarySideBar?'icon-bottom':'hidden'
         break;
     }
-  }
-  else {
-    switch (layoutConfig.value.activityBarPosition) {
-      case 'side':
-        panels.value.secondary.tabStyle = 'icon';
-        break;
-      case 'hidden':
-        panels.value.secondary.tabStyle = 'hidden';
-        break;
-      case 'top':
-        panels.value.secondary.tabStyle = layoutConfig.value.activityBar ? 'icon' : 'hidden';
-        break;
-      case 'bottom':
-        panels.value.secondary.tabStyle = layoutConfig.value.activityBar ? 'icon-bottom' : 'hidden';
-        break;
-    }
-  }
+ 
 }
 
-watch(() => layoutConfig.value.secondarySideBarAsActivityBar, loadActivityBarPosition);
 watch(() => layoutConfig.value.secondaryActivityBarPosition, loadActivityBarPosition);
 watch(() => layoutConfig.value.activityBarPosition, loadActivityBarPosition);
 watch(() => layoutConfig.value.activityBar, loadActivityBarPosition);

--- a/library/CodeLayoutBase.vue
+++ b/library/CodeLayoutBase.vue
@@ -25,7 +25,7 @@
         <slot name="activityBar" />
       </div>
       <div 
-        v-show="config.secondarySideBarAsActivityBar && config.primarySideBarPosition === 'right' && config.secondaryActivityBarPosition === 'side'" 
+        v-show=" config.primarySideBarPosition === 'right' && config.secondaryActivityBarPosition === 'side'" 
         :class="['code-layout-activity-bar','left']"
       >
         <slot name="activityBarSecondary" />
@@ -56,7 +56,7 @@
         <slot name="activityBar" />
       </div>
       <div 
-        v-show="config.secondarySideBarAsActivityBar && config.primarySideBarPosition === 'left' && config.secondaryActivityBarPosition === 'side'" 
+        v-show=" config.primarySideBarPosition === 'left' && config.secondaryActivityBarPosition === 'side'" 
         :class="['code-layout-activity-bar','right']"
       >
         <slot name="activityBarSecondary" />

--- a/library/CodeLayoutGroupRender.vue
+++ b/library/CodeLayoutGroupRender.vue
@@ -199,7 +199,7 @@ const showTitleBar = computed(() => {
     return false;
   if (layoutConfig.value.activityBarSubGroupShowTitle)
     return group.value.parentGrid === 'primarySideBar' || 
-      (group.value.parentGrid === 'secondarySideBar' && layoutConfig.value.secondarySideBarAsActivityBar);
+      (group.value.parentGrid === 'secondarySideBar');
   return false;
 });
 

--- a/library/Components/OverflowCollapseList.vue
+++ b/library/Components/OverflowCollapseList.vue
@@ -166,6 +166,9 @@ function onOverflowItemClicked() {
   }
   menuState = true;
   ContextMenu.showContextMenu({
+    onClose() {
+      setTimeout(() => menuState = false, 100);
+    },
     theme: 'code-layout',
     adjustPadding: { x: 0, y: 0 },
     x: horizontal ? 

--- a/library/Composeable/PanelMenu.ts
+++ b/library/Composeable/PanelMenu.ts
@@ -50,9 +50,7 @@ export const PanelMenuBuiltins : Record<string, PanelMenuRegistryItem> = {
   'panelPosition': { 
     create: (panel, t, data) => {
       return [
-        ...((panel.parentGrid === 'primarySideBar' || (
-          panel.parentGrid === 'secondarySideBar' && 
-          !data.layoutConfig.value.secondarySideBarAsActivityBar)
+        ...((panel.parentGrid === 'primarySideBar'
         ) ? [
           { 
             label: t('activityBarPosition'),
@@ -80,41 +78,8 @@ export const PanelMenuBuiltins : Record<string, PanelMenuRegistryItem> = {
               },
             ]
           },
-          ...(panel.parentGrid === 'secondarySideBar' ? [
-            { 
-              label: data.layoutConfig.value.primarySideBarPosition === 'left' ? 
-                t('moveSecondarySideBarLeft') : t('moveSecondarySideBarRight'),
-              onClick() {
-                data.layoutConfig.value.primarySideBarPosition =
-                  (data.layoutConfig.value.primarySideBarPosition === 'left') ? 'right' : 'left';
-              }
-            },
-            { 
-              label:`${t('hide')} ${t('secondarySideBar')}`,
-              hidden: !data.layoutConfig.value.secondarySideBar,
-              onClick() {
-                data.context.relayoutTopGridProp('secondarySideBar', false);
-              }
-            },
-          ] : [
-            { 
-              label: data.layoutConfig.value.primarySideBarPosition === 'left' ? 
-                t('movePrimarySideBarRight') : t('movePrimarySideBarLeft'),
-              onClick() {
-                data.layoutConfig.value.primarySideBarPosition =
-                  (data.layoutConfig.value.primarySideBarPosition === 'left') ? 'right' : 'left';
-              }
-            },
-            { 
-              label:`${t('hide')} ${t('primarySideBar')}`,
-              hidden: !data.layoutConfig.value.primarySideBar,
-              onClick() {
-                data.context.relayoutTopGridProp('primarySideBar', false);
-              }
-            },
-          ]),
         ] as MenuItem[] : []),
-        ...((panel.parentGrid === 'secondarySideBar' && data.layoutConfig.value.secondarySideBarAsActivityBar) ? [
+        ...((panel.parentGrid === 'secondarySideBar') ? [
           { 
             label: t('secondaryActivityBarPosition'),
             divided: 'up',


### PR DESCRIPTION
1. 文档更新
2. 解决 https://github.com/imengyu/vue-code-layout/issues/30#issuecomment-3589292319 中的问题3
3. 优化左右活动栏的 Tab 位置设置，使其互相独立，互不干扰。移除 secondarySideBarAsActivityBar 配置，此配置不影响 Tab 位置的设置。